### PR TITLE
[FIXED JENKINS-27627] remove color classes after new build

### DIFF
--- a/src/main/webapp/js/views/dashboard.js
+++ b/src/main/webapp/js/views/dashboard.js
@@ -34,7 +34,7 @@ define([
 
 			$.tmpl(this.template, data).appendTo(this.$el);
 
-			this.$el.addClass('job-status-' + this.model.get('status'));
+			this.$el.removeClass('job-status-ok job-status-ko job-status-instable job-status-glow').addClass('job-status-' + this.model.get('status'));
 			this.$el.toggleClass('job-building', this.model.get('building'));
 
 			// BUG: Seems to be caused by toggling the job-building class, making


### PR DESCRIPTION
After a build goes to status failed or instable, it does not transition back to status green on EzWall. This removes the remaining class and adds the correct one again.
