### PR TITLE
[FIXED JENKINS-27627] Color fixes

### DIFF
--- a/src/main/webapp/js/views/dashboard.js
+++ b/src/main/webapp/js/views/dashboard.js
@@ -34,7 +34,7 @@ define([
 
 			$.tmpl(this.template, data).appendTo(this.$el);
 
-			this.$el.addClass('job-status-' + this.model.get('status'));
+			this.$el.removeClass('job-status-ok job-status-ko job-status-instable job-status-glow').addClass('job-status-' + this.model.get('status'));
 			this.$el.toggleClass('job-building', this.model.get('building'));
 
 			// BUG: Seems to be caused by toggling the job-building class, making

--- a/src/main/webapp/js/views/dashboard.js
+++ b/src/main/webapp/js/views/dashboard.js
@@ -34,7 +34,7 @@ define([
 
 			$.tmpl(this.template, data).appendTo(this.$el);
 
-			this.$el.removeClass('job-status-ok job-status-ko job-status-instable job-status-glow').addClass('job-status-' + this.model.get('status'));
+			this.$el.removeClass('job-status-ko job-status-ok job-status-instable job-status-glow').addClass('job-status-' + this.model.get('status'));
 			this.$el.toggleClass('job-building', this.model.get('building'));
 
 			// BUG: Seems to be caused by toggling the job-building class, making


### PR DESCRIPTION
When running a job it adds a HTML class without removing the previous ones. This causes glitches where succesful build are still marked as failed on the EzWall screen
