### PR TITLE
Fix when jenkins is deployed in sub URL

### DIFF
--- a/src/main/resources/jenkins/plugins/ezwall/EzWallViewAction/index.jelly
+++ b/src/main/resources/jenkins/plugins/ezwall/EzWallViewAction/index.jelly
@@ -1,17 +1,19 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
 <st:contentType value="text/html;charset=UTF-8" />
+
+<j:set var="resourcesURL" value="${app.rootUrl}plugin/ezwall" />
 <x:doctype name="html" />
 <html>
 
   <head>
     <meta charset="utf-8"/>
     <title>EZWall</title>
-    <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/ezwall/css/Aristo/Aristo.css" />
-    <link rel="stylesheet" type="text/css" href="${rootURL}/plugin/ezwall/css/ezwall.css" />  
+    <link rel="stylesheet" type="text/css" href="${resourcesURL}/css/Aristo/Aristo.css" />
+    <link rel="stylesheet" type="text/css" href="${resourcesURL}/css/ezwall.css" />  
     <script type="text/javascript"
-    	src="${rootURL}/plugin/ezwall/js/require.js"
-    	data-main="${rootURL}/plugin/ezwall/js/main">
+    	src="${resourcesURL}/js/require.js"
+    	data-main="${resourcesURL}/js/main">
     </script>
   </head>
 
@@ -20,7 +22,7 @@
       <div id="dashboard"></div>
       <div id="header-display-zone"></div>
       <header id="header" class="header"></header>
-    </div>    
+    </div>
   </body>
 
 </html>

--- a/src/main/resources/jenkins/plugins/ezwall/EzWallViewAction/index.jelly
+++ b/src/main/resources/jenkins/plugins/ezwall/EzWallViewAction/index.jelly
@@ -2,7 +2,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:x="jelly:xml">
 <st:contentType value="text/html;charset=UTF-8" />
 
-<j:set var="resourcesURL" value="${app.rootUrl}plugin/ezwall" />
+<j:new var="h" className="hudson.Functions"/>
+${h.initPageVariables(context)}
+
+<j:set var="resourcesURL" value="${resURL}/plugin/ezwall" />
 <x:doctype name="html" />
 <html>
 


### PR DESCRIPTION
rootUrl is always empty, so when jenkins is accessible with url like http://server/jenkins, the plugin does not display anything.
Need to to initialize the context and use the variable resURL.
Inspired from the Build Monitor Plugin